### PR TITLE
feat: add did-eth identifier to specification draft

### DIFF
--- a/did-eth-method-draft.md
+++ b/did-eth-method-draft.md
@@ -34,7 +34,7 @@ or the corresponding HEX-encoded Ethereum address on the target network, prefixe
     network-chain-id = "0x" *HEXDIG
     ethereum-address = "0x" 40*HEXDIG
     public-key-hex = "0x" 66*HEXDIG
-    ens-name = website ".eth"
+    ens-name = [optional subdomain] + [domain name] + [top level domain supported by ENS]
 
 The `ethereum-address` or `public-key-hex` or `ens-name` are case-insensitive, however, the corresponding `blockchainAccountId`
 MAY be represented using
@@ -44,9 +44,10 @@ in the resulting DID document.
 Note, if no public Ethereum network was specified, it is assumed that the DID is anchored on the Ethereum mainnet by
 default. This means the following DIDs will resolve to equivalent DID Documents:
 
-    did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a
-    did:ethr:0x1:0xb9c5714089478a327f09197987f16f9e5d936e8a
-    did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a
+    did:eth:mainnet:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+    did:eth:0x1:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+    did:eth:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+    did:eth:vitalik.eth
 
 If the identifier is a `public-key-hex`:
 

--- a/did-eth-method-draft.md
+++ b/did-eth-method-draft.md
@@ -34,6 +34,8 @@ Examples:
   * Hedera: did:eth:eip155:296:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011
   * Sepiola Testnet: did:eth:eip155:11155111:0xb9c5714089478a327f09197987f16f9e5d936e8a
 
+There is no "default" representation reserved for Ethereum mainnet (or any other chain). All identifiers MUST include the [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) namespace and chain_id explicitly
+
 ### Examples
 
 

--- a/did-eth-method-draft.md
+++ b/did-eth-method-draft.md
@@ -20,47 +20,19 @@
 
 The namestring that shall identify this DID method is: `eth`
 
-A DID that uses this method MUST begin with the following prefix: `did:eth`. Per the DID specification, this string
+A DID that uses this method MUST begin with the following prefix: `did:eth:`. Per the DID specification, this string
 MUST be in lowercase. The remainder of the DID, after the prefix, is specified below.
 
 ## Method Specific Identifier
 
-The method specific identifier is represented as the HEX-encoded secp256k1 public key (in compressed form),
-or the corresponding HEX-encoded Ethereum address on the target network, prefixed with `0x`.
+The method specific identifier should be understood simply as a [CAIP-10 compliant identifier](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md), prefixed with the "did:eth:". In other words:
+  * eth-did = "did:eth:" + CAIP-10 Identifier
 
-    eth-did = "did:ethr:" eth-specific-identifier
-    eth-specific-identifier = [ ethr-network ":" ] ethereum-address / public-key-hex / ens-name
-    eth-network = "mainnet" / "goerli" / network-chain-id
-    network-chain-id = "0x" *HEXDIG
-    ethereum-address = "0x" 40*HEXDIG
-    public-key-hex = "0x" 66*HEXDIG
-    ens-name = [optional subdomain] + [domain name] + [top level domain supported by ENS]
-
-The `ethereum-address` or `public-key-hex` or `ens-name` are case-insensitive, however, the corresponding `blockchainAccountId`
-MAY be represented using
-the [mixed case checksum representation described in EIP55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md)
-in the resulting DID document.
-
-Note, if no public Ethereum network was specified, it is assumed that the DID is anchored on the Ethereum mainnet by
-default. This means the following DIDs will resolve to equivalent DID Documents:
-
-    did:eth:mainnet:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
-    did:eth:0x1:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
-    did:eth:0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
-    did:eth:vitalik.eth
-
-If the identifier is a `public-key-hex`:
-
-- it MUST be represented in compressed form (see https://en.bitcoin.it/wiki/Secp256k1)
-- the corresponding `blockchainAccountId` entry is also added to the default DID document, unless the `owner` property
-  has been changed to a different address.
-- all Read, Update, and Delete operations MUST be made using the corresponding `blockchainAccountId` and MUST originate
-  from the correct controller account (ECR1056 `owner`).
-
-If the `eth-specific-identifier` is a `ens-name`:
-
-- the `chainId` MUST be "mainnet" ("0x1") or "goerli" ("0x5")
-- the `controller` of the ENS Name is used as the `blockchainAccountId` of the DID
+Examples:
+  * Ethereum: did:eth:eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a
+  * Polygon: did:eth:eip155:137:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5
+  * Hedera: did:eth:eip155:296:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011
+  * Sepiola Testnet: did:eth:eip155:11155111:0xb9c5714089478a327f09197987f16f9e5d936e8a
 
 ### Examples
 

--- a/did-eth-method-draft.md
+++ b/did-eth-method-draft.md
@@ -32,7 +32,7 @@ Examples:
   * Ethereum: did:eth:eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a
   * Polygon: did:eth:eip155:137:0x4e90e8a8191c1c23a24a598c3ab4fb47ce926ff5
   * Hedera: did:eth:eip155:296:0xa0ae58da58dfa46fa55c3b86545e7065f90ff011
-  * Sepiola Testnet: did:eth:eip155:11155111:0xb9c5714089478a327f09197987f16f9e5d936e8a
+  * Sepolia Testnet: did:eth:eip155:11155111:0xb9c5714089478a327f09197987f16f9e5d936e8a
 
 There is no "default" representation reserved for Ethereum mainnet (or any other chain). All identifiers MUST include the [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) namespace and chain_id explicitly
 

--- a/did-eth-method-draft.md
+++ b/did-eth-method-draft.md
@@ -16,15 +16,50 @@
 ## Design Goals
 
 
-## Identifier scheme
+## DID Method Name
 
-### Syntax and Interpretation
+The namestring that shall identify this DID method is: `eth`
 
-```
-eth-did    = "did:eth:<chain_id>:" address
-chain_id   = chain_id according to [CAIP-2]
-address    = account_id according to [CAIP-10]
-```
+A DID that uses this method MUST begin with the following prefix: `did:eth`. Per the DID specification, this string
+MUST be in lowercase. The remainder of the DID, after the prefix, is specified below.
+
+## Method Specific Identifier
+
+The method specific identifier is represented as the HEX-encoded secp256k1 public key (in compressed form),
+or the corresponding HEX-encoded Ethereum address on the target network, prefixed with `0x`.
+
+    eth-did = "did:ethr:" eth-specific-identifier
+    eth-specific-identifier = [ ethr-network ":" ] ethereum-address / public-key-hex / ens-name
+    eth-network = "mainnet" / "goerli" / network-chain-id
+    network-chain-id = "0x" *HEXDIG
+    ethereum-address = "0x" 40*HEXDIG
+    public-key-hex = "0x" 66*HEXDIG
+    ens-name = website ".eth"
+
+The `ethereum-address` or `public-key-hex` or `ens-name` are case-insensitive, however, the corresponding `blockchainAccountId`
+MAY be represented using
+the [mixed case checksum representation described in EIP55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md)
+in the resulting DID document.
+
+Note, if no public Ethereum network was specified, it is assumed that the DID is anchored on the Ethereum mainnet by
+default. This means the following DIDs will resolve to equivalent DID Documents:
+
+    did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a
+    did:ethr:0x1:0xb9c5714089478a327f09197987f16f9e5d936e8a
+    did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a
+
+If the identifier is a `public-key-hex`:
+
+- it MUST be represented in compressed form (see https://en.bitcoin.it/wiki/Secp256k1)
+- the corresponding `blockchainAccountId` entry is also added to the default DID document, unless the `owner` property
+  has been changed to a different address.
+- all Read, Update, and Delete operations MUST be made using the corresponding `blockchainAccountId` and MUST originate
+  from the correct controller account (ECR1056 `owner`).
+
+If the `eth-specific-identifier` is a `ens-name`:
+
+- the `chainId` MUST be "mainnet" ("0x1") or "goerli" ("0x5")
+- the `controller` of the ENS Name is used as the `blockchainAccountId` of the DID
 
 ### Examples
 


### PR DESCRIPTION
- one thing to think about is should the resolved DID referenced by ENS Name be identical to the DID referenced by that ENS Name's Controller? Or should they be separate DIDs?