### PR TITLE
chore: disable renovate bot as we don't have checks yet

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "enabled": false
 }


### PR DESCRIPTION
This bot will be very useful for keeping things up-to-date once we have some checks in place.
For now it is only generating noise, so I'm disabling it.