### PR TITLE
chore: Implement continuous integration build for registry container

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -1,0 +1,33 @@
+name: Build Image CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - "*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build
+        uses: docker/build-push-action@v3
+        with:
+          context: packages/did-eth-registry
+          platforms: linux/amd64
+          push: false


### PR DESCRIPTION
closes #54

This is a small follow up pr to enable the continuous integration for the registry!    I didn't want to tack this on to the previous PR to keep my change small but this will be super useful after all.